### PR TITLE
Add basic EF Core setup with project/ticket pages

### DIFF
--- a/jiraclonenew/Data/ApplicationDbContext.cs
+++ b/jiraclonenew/Data/ApplicationDbContext.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using jiraclonenew.Models;
+
+namespace jiraclonenew.Data
+{
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Project> Projects => Set<Project>();
+        public DbSet<Ticket> Tickets => Set<Ticket>();
+    }
+}

--- a/jiraclonenew/Models/ApplicationUser.cs
+++ b/jiraclonenew/Models/ApplicationUser.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace jiraclonenew.Models
+{
+    public class ApplicationUser : IdentityUser
+    {
+        // Additional profile data can be added here
+    }
+}

--- a/jiraclonenew/Models/Project.cs
+++ b/jiraclonenew/Models/Project.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace jiraclonenew.Models
+{
+    public class Project
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        [StringLength(500)]
+        public string? Description { get; set; }
+
+        public ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();
+    }
+}

--- a/jiraclonenew/Models/Ticket.cs
+++ b/jiraclonenew/Models/Ticket.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace jiraclonenew.Models
+{
+    public enum TicketType { Story, Bug, Task, Epic, SubTask }
+    public enum TicketStatus { ToDo, InProgress, InReview, Done }
+    public enum TicketPriority { Low, Medium, High }
+
+    public class Ticket
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [StringLength(200)]
+        public string Title { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        public TicketType Type { get; set; } = TicketType.Task;
+        public TicketStatus Status { get; set; } = TicketStatus.ToDo;
+        public TicketPriority Priority { get; set; } = TicketPriority.Medium;
+
+        public string? AssigneeId { get; set; }
+        public ApplicationUser? Assignee { get; set; }
+
+        public string? ReporterId { get; set; }
+        public ApplicationUser? Reporter { get; set; }
+
+        public int ProjectId { get; set; }
+        public Project Project { get; set; } = null!;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/jiraclonenew/Pages/Projects/Create.cshtml
+++ b/jiraclonenew/Pages/Projects/Create.cshtml
@@ -1,0 +1,21 @@
+@page
+@model jiraclonenew.Pages.Projects.CreateModel
+@{
+    ViewData["Title"] = "Create Project";
+}
+
+<h1>Create Project</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Project.Name" class="form-label"></label>
+        <input asp-for="Project.Name" class="form-control" />
+        <span asp-validation-for="Project.Name" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Project.Description" class="form-label"></label>
+        <textarea asp-for="Project.Description" class="form-control"></textarea>
+        <span asp-validation-for="Project.Description" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>

--- a/jiraclonenew/Pages/Projects/Create.cshtml.cs
+++ b/jiraclonenew/Pages/Projects/Create.cshtml.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using jiraclonenew.Data;
+using jiraclonenew.Models;
+
+namespace jiraclonenew.Pages.Projects
+{
+    public class CreateModel : PageModel
+    {
+        private readonly ApplicationDbContext _context;
+
+        public CreateModel(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [BindProperty]
+        public Project Project { get; set; } = new Project();
+
+        public void OnGet()
+        {
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            _context.Projects.Add(Project);
+            await _context.SaveChangesAsync();
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/jiraclonenew/Pages/Projects/Index.cshtml
+++ b/jiraclonenew/Pages/Projects/Index.cshtml
@@ -1,0 +1,25 @@
+@page
+@model jiraclonenew.Pages.Projects.IndexModel
+@{
+    ViewData["Title"] = "Projects";
+}
+
+<h1>Projects</h1>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var project in Model.Projects)
+{
+        <tr>
+            <td>@project.Name</td>
+            <td>@project.Description</td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/jiraclonenew/Pages/Projects/Index.cshtml.cs
+++ b/jiraclonenew/Pages/Projects/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using jiraclonenew.Data;
+using jiraclonenew.Models;
+
+namespace jiraclonenew.Pages.Projects
+{
+    public class IndexModel : PageModel
+    {
+        private readonly ApplicationDbContext _context;
+
+        public IndexModel(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public IList<Project> Projects { get; set; } = new List<Project>();
+
+        public async Task OnGetAsync()
+        {
+            Projects = await _context.Projects.AsNoTracking().ToListAsync();
+        }
+    }
+}

--- a/jiraclonenew/Pages/Shared/_Layout.cshtml
+++ b/jiraclonenew/Pages/Shared/_Layout.cshtml
@@ -25,6 +25,12 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Projects/Index">Projects</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Tickets/Index">Tickets</a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/jiraclonenew/Pages/Tickets/Create.cshtml
+++ b/jiraclonenew/Pages/Tickets/Create.cshtml
@@ -1,0 +1,33 @@
+@page
+@model jiraclonenew.Pages.Tickets.CreateModel
+@{
+    ViewData["Title"] = "Create Ticket";
+}
+
+<h1>Create Ticket</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Ticket.Title" class="form-label"></label>
+        <input asp-for="Ticket.Title" class="form-control" />
+        <span asp-validation-for="Ticket.Title" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Ticket.Description" class="form-label"></label>
+        <textarea asp-for="Ticket.Description" class="form-control"></textarea>
+        <span asp-validation-for="Ticket.Description" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Ticket.Type" class="form-label"></label>
+        <select asp-for="Ticket.Type" asp-items="Html.GetEnumSelectList<TicketType>()" class="form-select"></select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Ticket.Priority" class="form-label"></label>
+        <select asp-for="Ticket.Priority" asp-items="Html.GetEnumSelectList<TicketPriority>()" class="form-select"></select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Ticket.ProjectId" class="form-label">Project</label>
+        <select asp-for="Ticket.ProjectId" asp-items="Model.ProjectOptions" class="form-select"></select>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>

--- a/jiraclonenew/Pages/Tickets/Create.cshtml.cs
+++ b/jiraclonenew/Pages/Tickets/Create.cshtml.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using jiraclonenew.Data;
+using jiraclonenew.Models;
+
+namespace jiraclonenew.Pages.Tickets
+{
+    public class CreateModel : PageModel
+    {
+        private readonly ApplicationDbContext _context;
+
+        public CreateModel(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [BindProperty]
+        public Ticket Ticket { get; set; } = new Ticket();
+
+        public SelectList ProjectOptions { get; set; } = null!;
+
+        public async Task OnGetAsync()
+        {
+            ProjectOptions = new SelectList(await _context.Projects.ToListAsync(), "Id", "Name");
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                ProjectOptions = new SelectList(await _context.Projects.ToListAsync(), "Id", "Name");
+                return Page();
+            }
+
+            _context.Tickets.Add(Ticket);
+            await _context.SaveChangesAsync();
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/jiraclonenew/Pages/Tickets/Index.cshtml
+++ b/jiraclonenew/Pages/Tickets/Index.cshtml
@@ -1,0 +1,29 @@
+@page
+@model jiraclonenew.Pages.Tickets.IndexModel
+@{
+    ViewData["Title"] = "Tickets";
+}
+
+<h1>Tickets</h1>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Title</th>
+            <th>Type</th>
+            <th>Status</th>
+            <th>Priority</th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var ticket in Model.Tickets)
+{
+        <tr>
+            <td>@ticket.Title</td>
+            <td>@ticket.Type</td>
+            <td>@ticket.Status</td>
+            <td>@ticket.Priority</td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/jiraclonenew/Pages/Tickets/Index.cshtml.cs
+++ b/jiraclonenew/Pages/Tickets/Index.cshtml.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using jiraclonenew.Data;
+using jiraclonenew.Models;
+
+namespace jiraclonenew.Pages.Tickets
+{
+    public class IndexModel : PageModel
+    {
+        private readonly ApplicationDbContext _context;
+
+        public IndexModel(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public IList<Ticket> Tickets { get; set; } = new List<Ticket>();
+
+        public async Task OnGetAsync()
+        {
+            Tickets = await _context.Tickets
+                .Include(t => t.Project)
+                .AsNoTracking()
+                .ToListAsync();
+        }
+    }
+}

--- a/jiraclonenew/Program.cs
+++ b/jiraclonenew/Program.cs
@@ -1,12 +1,30 @@
+using jiraclonenew.Data;
+using jiraclonenew.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddDbContext<jiraclonenew.Data.ApplicationDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+builder.Services.AddIdentity<jiraclonenew.Models.ApplicationUser, IdentityRole>()
+    .AddEntityFrameworkStores<jiraclonenew.Data.ApplicationDbContext>()
+    .AddDefaultTokenProviders();
+
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (!app.Environment.IsDevelopment())
+if (app.Environment.IsDevelopment())
+{
+    app.UseMigrationsEndPoint();
+}
+else
 {
     app.UseExceptionHandler("/Error");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
@@ -18,6 +36,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapRazorPages();

--- a/jiraclonenew/appsettings.Development.json
+++ b/jiraclonenew/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=jiraclonenew;Username=postgres;Password=postgres"
   }
 }

--- a/jiraclonenew/appsettings.json
+++ b/jiraclonenew/appsettings.json
@@ -6,4 +6,7 @@
     }
   },
   "AllowedHosts": "*"
+  ,"ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=jiraclonenew;Username=postgres;Password=postgres"
+  }
 }

--- a/jiraclonenew/jiraclonenew.csproj
+++ b/jiraclonenew/jiraclonenew.csproj
@@ -6,4 +6,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- configure EF Core with PostgreSQL and Identity
- add `ApplicationDbContext`, `ApplicationUser`, `Project`, and `Ticket` models
- create basic Razor Pages to list and create projects and tickets
- expose project and ticket navigation links in layout

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876aca974c832f867311c476fbe568