### PR TITLE
Add dashboard metrics and kanban layout

### DIFF
--- a/jiraclonenew/Pages/Index.cshtml
+++ b/jiraclonenew/Pages/Index.cshtml
@@ -1,6 +1,62 @@
 @page
 @model jiraclonenew.Pages.IndexModel
-@{ ViewData["Title"] = "Dashboard"; }
-<h1>Dashboard</h1>
-<p>Welcome to JiraClone!</p>
-<p><a class="btn btn-primary" asp-page="/Projects/Create">Create Project</a></p>
+@using jiraclonenew.Models
+@{
+    ViewData["Title"] = "Dashboard";
+}
+
+<h1 class="mb-4">Dashboard</h1>
+
+<div class="row text-center mb-5">
+    <div class="col-md-3 mb-3">
+        <div class="card shadow-sm dashboard-metric">
+            <div class="card-body">
+                <h6 class="text-muted">Projects</h6>
+                <h2>@Model.ProjectCount</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3 mb-3">
+        <div class="card shadow-sm dashboard-metric">
+            <div class="card-body">
+                <h6 class="text-muted">Tickets</h6>
+                <h2>@Model.TicketCount</h2>
+            </div>
+        </div>
+    </div>
+    @foreach (var kvp in Model.StatusCounts)
+    {
+        <div class="col-md-3 mb-3">
+            <div class="card shadow-sm dashboard-metric">
+                <div class="card-body">
+                    <h6 class="text-muted">@kvp.Key</h6>
+                    <h2>@kvp.Value</h2>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@foreach (var project in Model.Projects)
+{
+    <h2>@project.Name</h2>
+    <div class="row board mb-5">
+        @foreach (TicketStatus status in Enum.GetValues(typeof(TicketStatus)))
+        {
+            <div class="col-md-3">
+                <h5>@status</h5>
+                <div class="card mb-3" style="min-height:150px;">
+                    <div class="card-body p-2">
+                        @foreach (var ticket in Model.TicketsForStatus(project, status))
+                        {
+                            <div class="ticket-item border p-1 mb-2 rounded">
+                                <strong>@ticket.Title</strong>
+                                <div class="small text-muted">@ticket.Type - @ticket.Priority</div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+}

--- a/jiraclonenew/Pages/Index.cshtml.cs
+++ b/jiraclonenew/Pages/Index.cshtml.cs
@@ -1,11 +1,43 @@
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using jiraclonenew.Data;
+using jiraclonenew.Models;
 
 namespace jiraclonenew.Pages
 {
     public class IndexModel : PageModel
     {
-        public void OnGet()
+        private readonly ApplicationDbContext _context;
+
+        public IndexModel(ApplicationDbContext context)
         {
+            _context = context;
+        }
+
+        public int ProjectCount { get; set; }
+        public int TicketCount { get; set; }
+        public Dictionary<TicketStatus, int> StatusCounts { get; set; } = new();
+        public IList<Project> Projects { get; set; } = new List<Project>();
+
+        public async Task OnGetAsync()
+        {
+            Projects = await _context.Projects
+                .Include(p => p.Tickets)
+                .AsNoTracking()
+                .ToListAsync();
+
+            ProjectCount = Projects.Count;
+            TicketCount = Projects.Sum(p => p.Tickets.Count);
+
+            foreach (TicketStatus status in Enum.GetValues(typeof(TicketStatus)))
+            {
+                StatusCounts[status] = Projects.Sum(p => p.Tickets.Count(t => t.Status == status));
+            }
+        }
+
+        public IEnumerable<Ticket> TicketsForStatus(Project project, TicketStatus status)
+        {
+            return project.Tickets.Where(t => t.Status == status).OrderBy(t => t.Priority);
         }
     }
 }

--- a/jiraclonenew/wwwroot/css/site.css
+++ b/jiraclonenew/wwwroot/css/site.css
@@ -27,3 +27,9 @@ body {
   text-transform: capitalize;
   font-weight: bold;
 }
+
+/* Dashboard metric cards */
+.dashboard-metric h2 {
+  font-size: 2rem;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
- redesign Dashboard page with metrics and kanban board
- load project/ticket data in IndexModel
- add simple style for metric cards

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887998ebea8832f98af8155001edaf4