### PR TITLE
Add basic user management pages

### DIFF
--- a/jiraclonenew/Pages/Admin/Users/Edit.cshtml
+++ b/jiraclonenew/Pages/Admin/Users/Edit.cshtml
@@ -1,0 +1,27 @@
+@page "{id}"
+@model jiraclonenew.Pages.Admin.Users.EditModel
+@{
+    ViewData["Title"] = "Edit User";
+}
+
+<h1>Edit User</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label>Email</label>
+        <input class="form-control" value="@Model.Input.Email" readonly />
+    </div>
+    <fieldset>
+        <legend>Roles</legend>
+        @foreach (var role in Model.Input.Roles.Keys)
+        {
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="Input.Roles[@role]" value="true" @(Model.Input.Roles[role] ? "checked" : "") />
+                <input type="hidden" name="Input.Roles[@role]" value="false" />
+                <label class="form-check-label">@role</label>
+            </div>
+        }
+    </fieldset>
+    <button type="submit" class="btn btn-primary mt-3">Save</button>
+    <a asp-page="Index" class="btn btn-secondary mt-3">Cancel</a>
+</form>

--- a/jiraclonenew/Pages/Admin/Users/Edit.cshtml.cs
+++ b/jiraclonenew/Pages/Admin/Users/Edit.cshtml.cs
@@ -1,0 +1,67 @@
+using jiraclonenew.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace jiraclonenew.Pages.Admin.Users;
+
+public class EditModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly RoleManager<IdentityRole> _roleManager;
+
+    public EditModel(UserManager<ApplicationUser> userManager, RoleManager<IdentityRole> roleManager)
+    {
+        _userManager = userManager;
+        _roleManager = roleManager;
+    }
+
+    public class InputModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public Dictionary<string, bool> Roles { get; set; } = new();
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(string id)
+    {
+        var user = await _userManager.FindByIdAsync(id);
+        if (user == null) return NotFound();
+
+        Input.Id = user.Id;
+        Input.Email = user.Email;
+        foreach (var role in _roleManager.Roles)
+        {
+            bool inRole = await _userManager.IsInRoleAsync(user, role.Name!);
+            Input.Roles[role.Name!] = inRole;
+        }
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var user = await _userManager.FindByIdAsync(Input.Id);
+        if (user == null) return NotFound();
+
+        var currentRoles = await _userManager.GetRolesAsync(user);
+        foreach (var kvp in Input.Roles)
+        {
+            var roleName = kvp.Key;
+            var shouldHaveRole = kvp.Value;
+            bool hasRole = currentRoles.Contains(roleName);
+            if (shouldHaveRole && !hasRole)
+            {
+                await _userManager.AddToRoleAsync(user, roleName);
+            }
+            else if (!shouldHaveRole && hasRole)
+            {
+                await _userManager.RemoveFromRoleAsync(user, roleName);
+            }
+        }
+
+        return RedirectToPage("Index");
+    }
+}

--- a/jiraclonenew/Pages/Admin/Users/Index.cshtml
+++ b/jiraclonenew/Pages/Admin/Users/Index.cshtml
@@ -1,0 +1,47 @@
+@page
+@model jiraclonenew.Pages.Admin.Users.IndexModel
+@{
+    ViewData["Title"] = "Users";
+}
+
+<h1 class="mb-3">Users</h1>
+
+<form method="get" class="mb-3">
+    <div class="input-group">
+        <input type="text" name="Search" value="@Model.Search" class="form-control" placeholder="Search users" />
+        <button type="submit" class="btn btn-primary">Search</button>
+    </div>
+</form>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>User Name</th>
+            <th>Email</th>
+            <th>Roles</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var row in Model.Users)
+        {
+            <tr>
+                <td>@row.User.UserName</td>
+                <td>@row.User.Email</td>
+                <td>@string.Join(", ", row.Roles)</td>
+                <td><a asp-page="Edit" asp-route-id="@row.User.Id" class="btn btn-sm btn-secondary">Edit</a></td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+<nav>
+    <ul class="pagination">
+        @for (int i = 1; i <= Model.TotalPages; i++)
+        {
+            <li class="page-item @(i == Model.Page ? "active" : null)">
+                <a class="page-link" href="?page=@i&search=@Model.Search">@i</a>
+            </li>
+        }
+    </ul>
+</nav>

--- a/jiraclonenew/Pages/Admin/Users/Index.cshtml.cs
+++ b/jiraclonenew/Pages/Admin/Users/Index.cshtml.cs
@@ -1,0 +1,61 @@
+using jiraclonenew.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace jiraclonenew.Pages.Admin.Users;
+
+public class IndexModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public IndexModel(UserManager<ApplicationUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public class UserRow
+    {
+        public ApplicationUser User { get; set; } = new();
+        public IList<string> Roles { get; set; } = new List<string>();
+    }
+
+    public IList<UserRow> Users { get; set; } = new List<UserRow>();
+
+    [BindProperty(SupportsGet = true)]
+    public string? Search { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int Page { get; set; } = 1;
+
+    public int TotalPages { get; set; }
+
+    private const int PageSize = 10;
+
+    public async Task OnGetAsync()
+    {
+        var query = _userManager.Users.AsQueryable();
+        if (!string.IsNullOrWhiteSpace(Search))
+        {
+            query = query.Where(u => (u.UserName != null && u.UserName.Contains(Search)) ||
+                                     (u.Email != null && u.Email.Contains(Search)));
+        }
+
+        var count = await query.CountAsync();
+        TotalPages = (int)Math.Ceiling(count / (double)PageSize);
+        var users = await query
+            .OrderBy(u => u.UserName)
+            .Skip((Page - 1) * PageSize)
+            .Take(PageSize)
+            .ToListAsync();
+
+        foreach (var u in users)
+        {
+            Users.Add(new UserRow
+            {
+                User = u,
+                Roles = (await _userManager.GetRolesAsync(u)).ToList()
+            });
+        }
+    }
+}

--- a/jiraclonenew/Pages/Shared/_Layout.cshtml
+++ b/jiraclonenew/Pages/Shared/_Layout.cshtml
@@ -31,6 +31,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Boards/Index">Boards</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Admin/Users/Index">Users</a>
+                        </li>
                     </ul>
                     <ul class="navbar-nav">
                         @if (User.Identity?.IsAuthenticated ?? false)


### PR DESCRIPTION
## Summary
- add admin user management pages with role assignment and pagination
- link to Users page in the site layout

## Testing
- `dotnet build jiraclonenew/jiraclonenew.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879c3ebe3c832fab38ec82280598e3