### PR TITLE
Use config connection string

### DIFF
--- a/jiraclonenew/Program.cs
+++ b/jiraclonenew/Program.cs
@@ -6,8 +6,10 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseNpgsql("Host=localhost;Port=5432;Database=jiraclonenew;Username=postgres;Password=test1234"));
+    options.UseNpgsql(connectionString));
 
 //builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 


### PR DESCRIPTION
## Summary
- read the connection string from `appsettings.json` instead of hardcoding it

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688853103688832f9f64a54e50ad037f