### PR TITLE
Document connection string config

### DIFF
--- a/jiraclonenew/Program.cs
+++ b/jiraclonenew/Program.cs
@@ -6,8 +6,10 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseNpgsql("Host=localhost;Port=5432;Database=jiraclonenew;Username=postgres;Password=test1234"));
+    options.UseNpgsql(connectionString));
 
 //builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 

--- a/jiraclonenew/README.md
+++ b/jiraclonenew/README.md
@@ -8,7 +8,9 @@ Install the [.NET 8 SDK](https://dotnet.microsoft.com/download) to build and run
 
 ## Setup
 
-From the repository root run the following commands after configuring the connection string in *appsettings.json*:
+Before running the project you must configure a valid PostgreSQL connection string.  
+Update `appsettings.Development.json` (or set the `ConnectionStrings__DefaultConnection` environment variable) so the `Username` and `Password` match your local database credentials.  
+Once the connection string is configured run the following commands from the repository root:
 
 ```bash
 dotnet restore

--- a/jiraclonenew/appsettings.Development.json
+++ b/jiraclonenew/appsettings.Development.json
@@ -7,6 +7,6 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=jiraclonenew;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=jiraclonenew;Username=postgres;Password=test1234"
   }
 }


### PR DESCRIPTION
## Summary
- align dev connection string with production settings
- document configuring credentials in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688853103688832f9f64a54e50ad037f