### PR TITLE
Document connection string config

### DIFF
--- a/jiraclonenew/README.md
+++ b/jiraclonenew/README.md
@@ -8,7 +8,9 @@ Install the [.NET 8 SDK](https://dotnet.microsoft.com/download) to build and run
 
 ## Setup
 
-From the repository root run the following commands after configuring the connection string in *appsettings.json*:
+Before running the project you must configure a valid PostgreSQL connection string.  
+Update `appsettings.Development.json` (or set the `ConnectionStrings__DefaultConnection` environment variable) so the `Username` and `Password` match your local database credentials.  
+Once the connection string is configured run the following commands from the repository root. The application will automatically apply any pending migrations at startup:
 
 ```bash
 dotnet restore

--- a/jiraclonenew/appsettings.Development.json
+++ b/jiraclonenew/appsettings.Development.json
@@ -7,6 +7,6 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=jiraclonenew;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=jiraclonenew;Username=postgres;Password=test1234"
   }
 }


### PR DESCRIPTION
## Summary
- align dev connection string with production settings
- document configuring credentials in README
- ensure migrations run automatically on startup

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688853103688832f9f64a54e50ad037f