### PR TITLE
Use config connection string

### DIFF
--- a/jiraclonenew/Program.cs
+++ b/jiraclonenew/Program.cs
@@ -6,8 +6,10 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseNpgsql("Host=localhost;Port=5432;Database=jiraclonenew;Username=postgres;Password=test1234"));
+    options.UseNpgsql(connectionString));
 
 //builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
@@ -25,6 +27,13 @@ builder.Services.ConfigureApplicationCookie(options =>
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
+
+// Ensure database schema is up to date
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    db.Database.Migrate();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- read the connection string from `appsettings.json` instead of hardcoding it
- run database migrations automatically at startup so the schema stays in sync

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688853103688832f9f64a54e50ad037f